### PR TITLE
Add nowdir function and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,33 @@ The script will:
 ### Multi-Platform Support
 
 The script supports multi-platform installations. It uses `${TARGETOS}` and `${TARGETARCH}` to handle different operating systems and architectures. You can set these environment variables before running the script to specify the target platform.
+
+## Create and Navigate to Today's Work Directory
+
+This repository includes a bash script to create a directory with today's date in `~/work/YYYYMMdd` format and navigate into it.
+
+### Usage
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/jodiecunningham/bash-scripts.git
+   cd bash-scripts
+   ```
+
+2. Ensure the script is executable:
+   ```sh
+   chmod +x ~/misc/nowdir.sh
+   ```
+
+3. Run the script:
+   ```sh
+   bash ~/misc/nowdir.sh
+   ```
+
+The script will:
+- Ensure it's starting in the home directory.
+- Check if the function `nowdir` exists in `~/.bashrc`.
+- Add an alias to `~/.bashrc` for the function `nowdir` if it doesn't exist.
+- Source `~/.bashrc` after adding the alias.
+- Define the function `nowdir` to create a folder with today's date in `~/work/YYYYMMdd` format.
+- Change directory into the newly created folder.

--- a/misc/nowdir.sh
+++ b/misc/nowdir.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Ensure the script is starting in the home directory
+cd ~
+
+# Check if the function nowdir exists in ~/.bashrc
+if ! grep -q "function nowdir" ~/.bashrc; then
+  # Add alias to ~/.bashrc for the function nowdir
+  echo "alias nowdir='bash ~/misc/nowdir.sh'" >> ~/.bashrc
+  # Source ~/.bashrc
+  source ~/.bashrc
+fi
+
+# Define the function nowdir
+nowdir() {
+  # Create a folder with today's date in ~/work/YYYYMMdd format
+  folder=~/work/$(date +%Y%m%d)
+  mkdir -p "$folder"
+  # Change directory into the newly created folder
+  cd "$folder"
+}
+
+# Call the function nowdir
+nowdir
+
+# Ensure the script is executable
+chmod +x ~/misc/nowdir.sh


### PR DESCRIPTION
Fixes #2

Add `nowdir` script and update `README.md` for creating and navigating to today's work directory.

* **Add `nowdir` script (`misc/nowdir.sh`):**
  - Ensure the script starts in the home directory.
  - Check if the function `nowdir` exists in `~/.bashrc`.
  - Add an alias to `~/.bashrc` for the function `nowdir` if it doesn't exist.
  - Source `~/.bashrc` after adding the alias.
  - Define the function `nowdir` to create a folder with today's date in `~/work/YYYYMMdd` format.
  - Change directory into the newly created folder.
  - Ensure the script is executable.

* **Update `README.md`:**
  - Add instructions on how to use the `nowdir` script.
  - Include steps to ensure the script is executable.
  - Provide usage instructions to run the script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jodiecunningham/bash-scripts/issues/2?shareId=6d35f646-1b87-4677-ab6a-51b7635788ae).